### PR TITLE
Projectile cache ’~/.emacs.d/local/projectile/known-projects.el’ not writeable

### DIFF
--- a/modules/me-project.el
+++ b/modules/me-project.el
@@ -11,7 +11,7 @@
   :demand t
   :custom
   (projectile-cache-file (+directory-ensure (concat minemacs-cache-dir "projectile/cache.el")))
-  (projectile-known-projects-file (concat minemacs-local-dir "projectile/known-projects.el"))
+  (projectile-known-projects-file (+directory-ensure (concat minemacs-local-dir "projectile/known-projects.el")))
   (projectile-ignored-projects '("~/"))
   (projectile-ignored-project-function nil) ;; TODO: customize it
   (projectile-auto-discover nil)


### PR DESCRIPTION
Projectile cache ’~/.emacs.d/local/projectile/known-projects.el’ not writeable
https://github.com/abougouffa/minemacs/issues/12#issue-1579061170

when SPC p a  to try add new project
will write to  known-projects.el. not  cache.el
so this pr can  fix this problem