### PR TITLE
Fix FAQ link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -160,5 +160,5 @@ by MinEmacs can be found in the [documentation generated from the source code](/
 
 ## Troubleshooting
 
-If you experienced an issue with MinEmacs, you can check the [FAQ](FAQ.md), check [open
+If you experienced an issue with MinEmacs, you can check the [FAQ](/docs/FAQ.md), check [open
 issues or open a new one](https://github.com/abougouffa/minemacs/issues).


### PR DESCRIPTION
The link to FAQ.md was lacking “/docs/” in its path.